### PR TITLE
Remove additional nodejs and yarn install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,7 @@ RUN apk add --no-cache \
       freetype-dev \
       harfbuzz \
       ca-certificates \
-      ttf-freefont \
-      nodejs \
-      yarn
+      ttf-freefont
 
 COPY ./package.json .
 COPY ./yarn.lock .


### PR DESCRIPTION
As the base image is node:12-alpine, there is no need to install node.js or yarn manually from Alpine package registry, this will save about 30MB of the image size, speed up the image build/pull/push process and use less disk space.

```sh
$ docker run --rm -it node:12-alpine /bin/sh -c "node --version && yarn --version"
v12.22.1
1.22.5
```