### PR TITLE
Clean up yarn cache after `yarn install` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,8 @@ COPY ./package.json .
 COPY ./yarn.lock .
 
 # Install shieldy dependencies
-RUN yarn install
+RUN yarn install \
+ && yarn cache clean
 
 COPY ./tsconfig.json .
 COPY ./scripts ./scripts


### PR DESCRIPTION
This will save about 80MB of the image size, which is very significant.