### PR TITLE
Remove not useful npm clean up command in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,4 @@ COPY ./entrypoint.sh .
 
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
-RUN rm -rf /usr/local/lib/node_modules/npm/ /usr/local/bin/npm
-
 CMD ["./entrypoint.sh"]


### PR DESCRIPTION
As Docker images are multiple layers, all the later(upper) ones are built upon the older(lower) images, clean up the image on the newer image will not work at all, and also, the base image is node:12-alpine, which contains npm by default, and which means it's not possible that we can clean it up, unless the whole image is squashed into a single layer(bad practice, layers not reusable/cachable between images), so this command can basically be removed.