### PR TITLE
Fix users being banned permanently

### DIFF
--- a/src/helpers/newcomers/kickCandidates.ts
+++ b/src/helpers/newcomers/kickCandidates.ts
@@ -30,7 +30,7 @@ export async function kickCandidates(chat: Chat, candidates: Candidate[]) {
       kickChatMemberProxy(
         chat.id,
         candidate.id,
-        chat.banUsers ? 0 : parseInt(`${new Date().getTime() / 1000 + 45}`)
+        chat.banUsers
       )
     } catch (err) {
       report(err, addKickedUser.name)
@@ -52,14 +52,18 @@ export async function kickCandidates(chat: Chat, candidates: Candidate[]) {
 async function kickChatMemberProxy(
   id: number,
   candidateId: number,
-  duration: number
+  banUsers: boolean
 ) {
   try {
     if (!chatMembersBeingKicked[id]) {
       chatMembersBeingKicked[id] = {}
     }
     chatMembersBeingKicked[id][candidateId] = true
-    await bot.telegram.kickChatMember(id, candidateId, duration)
+    if (banUsers) {
+      await bot.telegram.kickChatMember(id, candidateId)
+    } else {
+      await bot.telegram.unbanChatMember(id, candidateId) // kick without ban
+    }
   } catch (err) {
     report(err, kickChatMemberProxy.name)
   } finally {

--- a/src/helpers/newcomers/kickChatMember.ts
+++ b/src/helpers/newcomers/kickChatMember.ts
@@ -11,11 +11,12 @@ export async function kickChatMember(chat: DocumentType<Chat>, user: User) {
   // Try kicking the member
   try {
     await addKickedUser(chat, user.id)
-    await bot.telegram.kickChatMember(
-      chat.id,
-      user.id,
-      chat.banUsers ? 0 : parseInt(`${new Date().getTime() / 1000 + 45}`)
-    )
+    if (chat.banUsers) {
+      await bot.telegram.kickChatMember(chat.id, user.id)
+    } else {
+      // unban will kick user from the chat, but will not ban
+      await bot.telegram.unbanChatMember(chat.id, user.id)
+    }
   } catch (err) {
     report(err, kickChatMember.name)
   }

--- a/src/helpers/newcomers/kickChatMember.ts
+++ b/src/helpers/newcomers/kickChatMember.ts
@@ -14,8 +14,7 @@ export async function kickChatMember(chat: DocumentType<Chat>, user: User) {
     if (chat.banUsers) {
       await bot.telegram.kickChatMember(chat.id, user.id)
     } else {
-      // unban will kick user from the chat, but will not ban
-      await bot.telegram.unbanChatMember(chat.id, user.id)
+      await bot.telegram.unbanChatMember(chat.id, user.id) // kick without ban
     }
   } catch (err) {
     report(err, kickChatMember.name)


### PR DESCRIPTION
In the previous version, when `chat.banUsers` is set to `false`, we use ```parseInt(`${new Date().getTime() / 1000 + 45}`)``` to ban a user for 45 seconds. The intention is that the ban will be automatically lifted after 45 seconds. In practice, however, this often does not work, and will cause the user to be banned permanently, which has been raised in #106.

In this pull request, I substitute the 45-second approach with the [`bot.telegram.unbanChatMember`](https://core.telegram.org/bots/api#unbanchatmember) API, which will remove a member from the chat (similar to `bot.telegram.kickChatMember`) but without banning it.